### PR TITLE
[W01D2]feat: MVP pipeline + proof + clean repo (gitignore fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 .ruff_cache/
 .env
 .DS_Store
+data/processed/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A lakehouse-style data engineering pipeline repo (skeleton) with reproducible commands and CI.
 
+
+
 ## Quickstart
 
 ```bash
@@ -9,3 +11,4 @@ cp .env.example .env
 make setup
 make lint
 make test
+python -m src.de_lakehouse_pipeline.main

--- a/data/raw/sample.csv
+++ b/data/raw/sample.csv
@@ -1,0 +1,5 @@
+id,name,amount
+1,Alice,10
+2,Bob,0
+3,Chris,7
+4,,5

--- a/docs/WEEKLY_LOG.md
+++ b/docs/WEEKLY_LOG.md
@@ -6,3 +6,26 @@
 - Done: repo skeleton (Makefile targets + CI + docs)
 - Proof: `docs/proof/`
 - Next: implement the first main feature block skeleton
+
+### Day 2 (2026-2-21)
+### What I did
+- Implemented a minimal ETL pipeline (Extract → Transform → Load)
+- Read data from `data/raw/sample.csv`
+- Applied simple transformations (drop missing values, filter rows)
+- Saved output to `data/processed/output.csv`
+- Added proof of execution in `docs/proof/`
+- Updated README with run instructions
+
+### What I learned
+- How to structure a data engineering repo (src/, data/, docs/)
+- How to run Python modules using `python -m`
+- Importance of reproducibility (Makefile + README)
+- Basic ETL pipeline workflow
+
+### Issues / Challenges
+- Module import issue (`de_lakehouse_pipeline` not found)
+- Learned to fix it using `python -m src.de_lakehouse_pipeline.main`
+
+### Next steps
+- Improve pipeline structure
+- Add logging and configuration

--- a/docs/proof/2026-02-21-run.txt
+++ b/docs/proof/2026-02-21-run.txt
@@ -1,0 +1,13 @@
+Commands:
+make lint
+make test
+python -m src.de_lakehouse_pipeline.main
+
+Output:
+(All tests passed)
+Starting pipeline...
+Loaded 4 rows from data/raw/sample.csv
+Dropped 1 rows with missing name
+Filtered out 1 rows where amount <= 0
+Saved 2 rows to data/processed/output.csv
+Pipeline finished successfully

--- a/src/de_lakehouse_pipeline/main.py
+++ b/src/de_lakehouse_pipeline/main.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+
+def main() -> None:
+    print("Starting pipeline...")
+
+    # Paths (relative to repo root)
+    input_path = Path("data/raw/sample.csv")
+    output_path = Path("data/processed/output.csv")
+
+    # --- Extract ---
+    if not input_path.exists():
+        raise FileNotFoundError(
+            f"Input file not found: {input_path}. Create data/raw/sample.csv first."
+        )
+
+    df = pd.read_csv(input_path)
+    print(f"Loaded {len(df)} rows from {input_path}")
+
+    # --- Transform (minimal + visible) ---
+    # 1) Drop rows where name is missing
+    before = len(df)
+    df = df.dropna(subset=["name"])
+    after = len(df)
+    print(f"Dropped {before - after} rows with missing name")
+
+    # 2) Keep only positive amount
+    before = len(df)
+    df = df[df["amount"] > 0]
+    after = len(df)
+    print(f"Filtered out {before - after} rows where amount <= 0")
+
+    # --- Load ---
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(output_path, index=False)
+    print(f"Saved {len(df)} rows to {output_path}")
+
+    print("Pipeline finished successfully")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Purpose
Implement a minimal ETL pipeline (Extract → Transform → Load)

## What changed
- Added main pipeline (`src/de_lakehouse_pipeline/main.py`)
- Read data from `data/raw/sample.csv`
- Applied basic transformations (drop missing values, filter rows)
- Saved output to `data/processed/output.csv`
- Added proof of execution in `docs/proof/`
- Updated README with run instructions
- Cleaned repo with `.gitignore` (ignored .venv, __pycache__, processed data)

## How to verify
Run:

```bash
make setup
make lint
make test
python -m src.de_lakehouse_pipeline.main