### PR TITLE
[W01D2]chore: add smoke test and Makefile run/smoke commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,9 @@ test:
 
 clean:
 	rm -rf $(VENV)
+
+run:
+	$(PY) -m src.de_lakehouse_pipeline.main
+
+smoke:
+	$(PY) -m pytest -v tests/test_smoke.py

--- a/docs/WEEKLY_LOG.md
+++ b/docs/WEEKLY_LOG.md
@@ -53,3 +53,19 @@ main → behavior / integration
 ### Next steps
 Push code and ensure CI passes
 Continue improving pipeline structure and documentation
+
+
+
+### make up Day 03 in(2026-2-21)
+### What I did
+- How to write a smoke (E2E) test using `tmp_path`
+- Difference between unit tests and pipeline-level tests
+- How Makefile helps standardize commands (`make test`, `make smoke`, etc.)
+
+### Issues / Challenges
+- `make run` failed due to module import issue (`src/` structure not recognized)
+- Needed to refactor pipeline to support testing (add `run_pipeline`)
+
+### Next steps
+- Fix `make run` so pipeline can run from CLI
+- Re-run and update proof with successful output

--- a/docs/proof/2026-02-21-run.txt
+++ b/docs/proof/2026-02-21-run.txt
@@ -15,13 +15,56 @@ Pipeline finished successfully
 
 This output should  be W1D03(for Testring)(make up day03)
 Commands:
-Commands:
 make lint
 make test
+
 Output:
 collected 4 items                                                                                                                         
-
 tests/test_pipeline.py::test_transform_normal_case PASSED                                                                           [ 25%]
 tests/test_pipeline.py::test_transform_drops_missing_name_and_nonpositive_amount PASSED                                             [ 50%] 
 tests/test_pipeline.py::test_main_raises_if_input_missing PASSED                                                                    [ 75%]
 tests/test_smoke.py::test_smoke PASSED                               
+
+This output should  be W1D04(make up day04)
+Commands:
+make lint
+make test
+make run
+make smoke
+
+Output:
+All checks passed!
+.venv/Scripts/python.exe -m pytest -v -s
+========================================================== test session starts ===========================================================
+platform win32 -- Python 3.11.9, pytest-9.0.2, pluggy-1.6.0 -- C:\Users\liuxu\de-lakehouse-pipeline\.venv\Scripts\python.exe
+cachedir: .pytest_cache
+rootdir: C:\Users\liuxu\de-lakehouse-pipeline
+collected 4 items                                                                                                                         
+
+tests/test_pipeline.py::test_transform_normal_case PASSED
+tests/test_pipeline.py::test_transform_drops_missing_name_and_nonpositive_amount PASSED
+tests/test_pipeline.py::test_main_raises_if_input_missing Starting pipeline...
+Input file not found: data\raw\sample.csv. Create data/raw/sample.csv first.
+PASSED
+tests/test_smoke.py::test_smoke_pipeline Starting pipeline...
+Loaded 3 rows from C:\Users\liuxu\AppData\Local\Temp\pytest-of-liuxu\pytest-12\test_smoke_pipeline0\sample.csv
+Transformed: 3 -> 1 rows
+Saved 1 rows to C:\Users\liuxu\AppData\Local\Temp\pytest-of-liuxu\pytest-12\test_smoke_pipeline0\output.csv
+Pipeline finished successfully
+PASSED
+
+=========================================================== 4 passed in 1.34s ============================================================ 
+.venv/Scripts/python.exe -m src.de_lakehouse_pipeline.main
+Starting pipeline...
+Loaded 4 rows from data\raw\sample.csv
+Transformed: 4 -> 2 rows
+Saved 2 rows to data\processed\output.csv
+Pipeline finished successfully
+.venv/Scripts/python.exe -m pytest -v tests/test_smoke.py
+========================================================== test session starts ===========================================================
+platform win32 -- Python 3.11.9, pytest-9.0.2, pluggy-1.6.0 -- C:\Users\liuxu\de-lakehouse-pipeline\.venv\Scripts\python.exe
+cachedir: .pytest_cache
+rootdir: C:\Users\liuxu\de-lakehouse-pipeline
+collected 1 item                                                                                                                          
+
+tests/test_smoke.py::test_smoke_pipeline PASSED      

--- a/src/de_lakehouse_pipeline/main.py
+++ b/src/de_lakehouse_pipeline/main.py
@@ -4,18 +4,15 @@ from pathlib import Path
 
 import pandas as pd
 
+
 def transform(df: pd.DataFrame) -> pd.DataFrame:
     df = df.dropna(subset=["name"])
     df = df[df["amount"] > 0]
     return df
 
 
-def main() -> None:
+def run_pipeline(input_path: Path, output_path: Path) -> pd.DataFrame:
     print("Starting pipeline...")
-
-    # Paths (relative to repo root)
-    input_path = Path("data/raw/sample.csv")
-    output_path = Path("data/processed/output.csv")
 
     # --- Extract ---
     if not input_path.exists():
@@ -26,25 +23,25 @@ def main() -> None:
     df = pd.read_csv(input_path)
     print(f"Loaded {len(df)} rows from {input_path}")
 
-    # --- Transform (minimal + visible) ---
-    # 1) Drop rows where name is missing
+    # --- Transform ---
     before = len(df)
-    df = df.dropna(subset=["name"])
-    after = len(df)
-    print(f"Dropped {before - after} rows with missing name")
-
-    # 2) Keep only positive amount
-    before = len(df)
-    df = df[df["amount"] > 0]
-    after = len(df)
-    print(f"Filtered out {before - after} rows where amount <= 0")
+    df2 = transform(df)
+    after = len(df2)
+    print(f"Transformed: {before} -> {after} rows")
 
     # --- Load ---
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    df.to_csv(output_path, index=False)
-    print(f"Saved {len(df)} rows to {output_path}")
+    df2.to_csv(output_path, index=False)
+    print(f"Saved {len(df2)} rows to {output_path}")
 
     print("Pipeline finished successfully")
+    return df2
+
+
+def main() -> None:
+    input_path = Path("data/raw/sample.csv")
+    output_path = Path("data/processed/output.csv")
+    run_pipeline(input_path=input_path, output_path=output_path)
 
 
 if __name__ == "__main__":

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,2 +1,35 @@
-def test_smoke():
-    assert True
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from src.de_lakehouse_pipeline.main  import run_pipeline
+
+
+def test_smoke_pipeline(tmp_path: Path) -> None:
+    # Arrange: create fake raw data
+    input_path = tmp_path / "sample.csv"
+    output_path = tmp_path / "output.csv"
+
+    df = pd.DataFrame(
+        {
+            "name": ["A", "B", None],
+            "amount": [10, -5, 20],
+        }
+    )
+    df.to_csv(input_path, index=False)
+
+    # Act
+    result = run_pipeline(input_path=input_path, output_path=output_path)
+
+    # Assert: output exists + behavior is correct
+    assert output_path.exists()
+
+    out_df = pd.read_csv(output_path)
+    assert len(out_df) == 1
+    assert out_df.iloc[0]["name"] == "A"
+    assert out_df.iloc[0]["amount"] == 10
+
+    # extra: returned df matches saved df
+    assert len(result) == 1


### PR DESCRIPTION
## What I did
- Added smoke (E2E) test using tmp_path
- Refactored pipeline to support run_pipeline()
- Added Makefile commands:
  - make run
  - make smoke

## Why
- Ensure pipeline can be tested end-to-end
- Move from unit tests → system-level testing
- Improve reproducibility with Makefile

## How to validate
```bash
make setup
make test
make smoke
make run   # (currently needs fix for module path)