### PR TITLE
[W01D3]docs: improve README with project overview, usage, and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 
 A lakehouse-style data engineering pipeline repo (skeleton) with reproducible commands and CI.
 
+---
 
+## What this project does
+
+This project implements a simple data pipeline:
+
+- Extract: reads raw CSV data
+- Transform: removes invalid rows (missing name, non-positive amount)
+- Load: writes cleaned data to processed folder
+
+---
 
 ## Quickstart
 

--- a/docs/WEEKLY_LOG.md
+++ b/docs/WEEKLY_LOG.md
@@ -56,7 +56,7 @@ Continue improving pipeline structure and documentation
 
 
 
-### make up Day 03 in(2026-2-21)
+### make up Day 04 in(2026-2-21)
 ### What I did
 - How to write a smoke (E2E) test using `tmp_path`
 - Difference between unit tests and pipeline-level tests
@@ -69,3 +69,16 @@ Continue improving pipeline structure and documentation
 ### Next steps
 - Fix `make run` so pipeline can run from CLI
 - Re-run and update proof with successful output
+
+## make uo Day 05 in(2026-2-22) 
+
+### What I did
+- Verified CI pipeline success on GitHub
+- Improved README for reproducibility
+- Added proof of successful pipeline run
+
+### Issues / Challenges
+- Understanding CI workflow and verification
+
+### Next steps
+- Expand pipeline with more realistic data

--- a/docs/proof/2026-02-20-ci.txt
+++ b/docs/proof/2026-02-20-ci.txt
@@ -1,0 +1,9 @@
+make run :
+Starting pipeline...
+Loaded 4 rows from data\raw\sample.csv
+Transformed: 4 -> 2 rows
+Saved 2 rows to data\processed\output.csv
+Pipeline finished successfully
+
+make test:
+(4 passed...)


### PR DESCRIPTION
## Summary
Improve README to make the project more understandable and reproducible.

## Changes
- Added project overview (extract → transform → load)
- Added usage instructions (how to run and test)
- Added example input and output
- Improved documentation clarity

## How to test
```bash
make setup
make run
make test