### PR TITLE
[W03D02]test: add SQL utility unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ clean:
 test:   #-V verbose  -k .. 模糊
 	$(PY) -m pytest -v	
 
-unit:	#-k = Filter tests by "name keywords"
-	$(PY) -m pytest -v tests/test_db_unit.py
+sql-utils:	
+	$(PY) -m pytest -v -s tests/test_sql_utils.py
 
 run:
 	$(PY) -m de_lakehouse_pipeline.main
@@ -44,6 +44,9 @@ smoke:	#在 Python 里：-m = run modul ,in pytest -m is marker
 	
 
 # --- DB ---------------
+#this for CI
+db-smoke:
+	$(PY) -m pytest -q tests/test_db_smoke.py -vv
 db-shell:
 	docker exec -it de_lakehouse_db psql -U lakehouse -d lakehouse
 
@@ -54,9 +57,8 @@ db-down:
 	docker compose down
 migrate:
 	$(PY) -m scripts.migrate
-	
-#this for CI
-db-smoke:
-	$(PY) -m pytest -q tests/test_db_smoke.py -vv
 
+unit:	
+	$(PY) -m pytest -v tests/test_db_unit.py
+	
 db-smoke-local: db-up migrate db-smoke

--- a/docs/WEEKLY_LOG.md
+++ b/docs/WEEKLY_LOG.md
@@ -2,7 +2,7 @@
 ## Template
 ## Week <W> — <Topic>
 ### W<WW>D<D> (<YYYY-MM-DD>)— <Title>
-**Deliverables**
+**Deliverables** 
 ...
 **Validation**
 ...
@@ -392,36 +392,46 @@
 - ERD and data model documentation still evolving
 
 
-### W03D1 (2026-03-03) — SQL Validation and Testing
+### W03D01 (2026-03-04) — SQL Validation and Testing
 
 **Deliverables**
 - Executed SQL queries in `sql/patterns_window.sql`
 - Verified deduplication logic using window functions
 - Ran data quality checks from `sql/quality_checks.sql`
 - Executed development workflow commands:
-  - `make migrate`
   - `make lint`
   - `make smoke`
-- Recorded proof artifact in `docs/proof/2026-03-03-run.txt`
+- Recorded proof in 
 
 **Validation**
 - SQL queries executed successfully in local Postgres
-- Database migration completed without errors
 - Lint checks passed
 - Smoke tests confirmed database connectivity and query execution
 - Workflow verified to be reproducible from command-line execution
+- Proof log recorded under:
+  - `docs/proof/2026-03-04-run.txt`
 
-**Challenges**
-- Ensuring local Postgres container was running before executing SQL queries
-- Verifying window function logic behaved correctly with available sample data
-- Confirming schema definitions matched the expected SQL queries
 
-**Fixes**
-- Verified database container status using `docker compose up -d`
-- Re-ran migration to ensure schema consistency
-- Validated queries manually and via smoke tests
 
-**Outcome**
-- SQL patterns and quality checks confirmed working in the local environment
-- Development workflow (`migrate + lint + smoke`) validated
-- Reproducible proof recorded for the pipeline validation step
+### W03D02 (2026-03-05) — SQL Utility Unit Tests
+
+**Deliverables**
+- Implemented SQL utility function tests for `split_sql_statements`
+- Added unit test file: `tests/test_sql_utils.py`
+- Implemented 4 unit tests:
+  - `test_split_sql_statements_basic`
+  - `test_split_sql_statements_removes_empty_fragments`
+  - `test_split_sql_statements_strips_whitespace`
+  - `test_split_sql_statements_empty_or_whitespace_input`
+- Verified correct SQL statement splitting logic
+- Recorded proof of successful test execution
+
+**Validation**
+- Ran lint check:
+  - `make lint`
+  - Result: All checks passed
+- Ran unit tests:
+  - `make sql-utils`
+  - Result: 4 tests passed
+- Proof log recorded under:
+  - `docs/proof/2026-03-05-run.txt`

--- a/docs/proof/W01/2026-02-19-run.txt
+++ b/docs/proof/W01/2026-02-19-run.txt
@@ -8,13 +8,9 @@ Iteration 1 — Initial test validation : repo skeleton
 Commands:
   make test
 
-Key Output:
+Output:
   collected 1 item
   tests/test_smoke.py::test_smoke PASSED
 
   1 passed in 0.02s
 
-Validation:
-  - Test framework (pytest) successfully configured
-  - Project structure is testable
-============================================================

--- a/docs/proof/W01/2026-02-21-run.txt
+++ b/docs/proof/W01/2026-02-21-run.txt
@@ -10,7 +10,7 @@ Commands:
   make test
   make run
 
-Key Output:
+Output:
   All checks passed!
   4 passed
 
@@ -21,11 +21,6 @@ Key Output:
   Saved 2 rows to data/processed/output.csv
   Pipeline finished successfully
 
-Validation:
-  - ETL pipeline runs end-to-end
-  - Output file generated successfully
-============================================================
-
 
 ============================================================
 Iteration 3 — Unit tests : core logic validation
@@ -33,18 +28,12 @@ Iteration 3 — Unit tests : core logic validation
 Commands:
   make test
 
-Key Output:
+Output:
   collected 4 items
   tests/test_pipeline.py::test_transform_normal_case PASSED
   tests/test_pipeline.py::test_transform_drops_missing_name_and_nonpositive_amount PASSED
   tests/test_pipeline.py::test_main_raises_if_input_missing PASSED
   tests/test_smoke.py::test_smoke PASSED
-
-Validation:
-  - Core transformation logic is tested
-  - Edge and failure cases are covered
-============================================================
-
 
 ============================================================
 Iteration 4 — Smoke / E2E test : pipeline validation
@@ -54,7 +43,7 @@ Commands:
   make run
   make smoke
 
-Key Output:
+Output:
   4 passed
 
   Starting pipeline...
@@ -64,11 +53,6 @@ Key Output:
   Pipeline finished successfully
 
   tests/test_smoke.py::test_smoke_pipeline PASSED
-
-Validation:
-  - Pipeline runs end-to-end via CLI
-  - Smoke test validates full workflow
-============================================================
 ============================================================
 Iteration 5 — CI validation & stable pipeline run 
 
@@ -76,7 +60,7 @@ Commands:
   make test
   make run
 
-Key Output:
+Output:
   4 passed
 
   Starting pipeline...
@@ -84,9 +68,3 @@ Key Output:
   Transformed: 4 -> 2 rows
   Saved 2 rows to data/processed/output.csv
   Pipeline finished successfully
-
-Validation:
-  - Tests pass consistently (local + CI)
-  - Pipeline runs reliably via Makefile
-============================================================
-

--- a/docs/proof/W01/2026-02-22-run.txt
+++ b/docs/proof/W01/2026-02-22-run.txt
@@ -10,7 +10,7 @@ Commands:
   make test
   make run
 
-Key Output:
+Output:
   (dependencies installed successfully)
   4 passed
 
@@ -19,8 +19,9 @@ Key Output:
   Transformed: 4 -> 2 rows
   Saved 2 rows to data/processed/output.csv
   Pipeline finished successfully
-
-Validation:
-  - Project runs from a fresh environment
-  - Results are reproducible via Makefile
 ============================================================
+
+Reproducible Commands:
+  make setup
+  make test
+  make run

--- a/docs/proof/W02/2026-02-23-run.txt
+++ b/docs/proof/W02/2026-02-23-run.txt
@@ -42,16 +42,6 @@ Output:
   tests/test_smoke.py::test_smoke_pipeline PASSED
 
   ==========================================================
-  RESULT: 5 passed
-
-============================================================
-Summary
-
-- Postgres successfully started via Docker
-- Migration script created table(s)
-- Seed script inserted data
-- Smoke test verified DB connectivity and data correctness
-- All tests passed (5/5)
 
 Reproducible Commands:
   make setup

--- a/docs/proof/W02/2026-02-24-run.txt
+++ b/docs/proof/W02/2026-02-24-run.txt
@@ -15,13 +15,11 @@ Command:
   make unit
 Output:
   collected 4 items
-
   tests/test_db_unit.py::test_load_db_config_defaults PASSED
   tests/test_db_unit.py::test_load_db_config_env_override PASSED
   tests/test_db_unit.py::test_make_dsn_contains_expected_fields PASSED
   tests/test_db_unit.py::test_wait_for_db_times_out_fast_on_bad_port PASSED
 
-  ==========================================================
   RESULT: 4 passed
 
 ============================================================
@@ -72,19 +70,7 @@ Output:
   tests/test_pipeline.py::test_main_raises_if_input_missing PASSED
   tests/test_smoke.py::test_smoke_pipeline PASSED
 
-  ==========================================================
   RESULT: 9 passed
-
-============================================================
-Summary
-
-- Unit tests added for DB utilities (config, DSN, timeout behavior)
-- Edge case (timeout) tested deterministically
-- Postgres successfully started via Docker
-- Migration script applied schema and seed data
-- DB smoke test verified connectivity and query execution
-- Full pipeline tests passed (9/9)
-- Workflow fully reproducible via Makefile commands
 
 ============================================================
 Reproducible Commands:

--- a/docs/proof/W02/2026-02-25-run.txt
+++ b/docs/proof/W02/2026-02-25-run.txt
@@ -1,11 +1,10 @@
-# Proof — W02D3 Smoke Test via Makefile (make smoke)
+# Proof — W02D3 Smoke Test via Makefile 
 # Date: 2026-02-25
 # Repo: de-lakehouse-pipeline
 
-
+===========================================================
 Command:
   make smoke
-
 Output:
   .venv/Scripts/python.exe -m pytest -m smoke
   ========================================================== test session starts ===========================================================
@@ -13,8 +12,7 @@ Output:
   rootdir: C:\Users\liuxu\de-lakehouse-pipeline
   configfile: pytest.ini
   collected 9 items / 8 deselected / 1 selected
-
   tests\test_db_smoke.py .                                                                                                            [100%]
-
-Result:
-  PASS — make smoke succeeds and smoke test runs and passes.
+===========================================================
+Reproducibility commands:
+  make smoke

--- a/docs/proof/W02/2026-02-26-run.txt
+++ b/docs/proof/W02/2026-02-26-run.txt
@@ -2,114 +2,68 @@ Proof — W02D4 CI + Reproducibility
 Date: 2026-02-26 (local, Windows)
 Repo: de-lakehouse-pipeline
 
-------------------------------------------------------------
-
+===========================================================
 Step 1 — Setup environment (venv + deps + editable install)
-
 Command:
-make setup
+    make setup
+Output:
+    python -m venv .venv
+    .venv/Scripts/python.exe -m pip install --upgrade pip
+    .venv/Scripts/python.exe -m pip install -r requirements.txt
+    .venv/Scripts/python.exe -m pip install -e .
+    Successfully installed de-lakehouse-pipeline-0.1.0
 
-Key Output:
-python -m venv .venv
-.venv/Scripts/python.exe -m pip install --upgrade pip
-.venv/Scripts/python.exe -m pip install -r requirements.txt
-.venv/Scripts/python.exe -m pip install -e .
-Successfully installed de-lakehouse-pipeline-0.1.0
-
-Validation:
-- Virtual environment created successfully
-- Dependencies installed
-- Project installed in editable mode (imports work without PYTHONPATH)
-
-------------------------------------------------------------
-
+===========================================================
 Step 2 — Start Postgres (Docker)
-
 Command:
-make db-up
-
+    make db-up
 Output:
-docker compose up -d
-[+] up 2/2
-Network de-lakehouse-pipeline_default Created
-Container de_lakehouse_db Created
-
-Validation:
-- Postgres container starts successfully
-
-------------------------------------------------------------
-
+    docker compose up -d
+    [+] up 2/2
+    Network de-lakehouse-pipeline_default Created
+    Container de_lakehouse_db Created
+===========================================================
 Step 3 — Run migrations + seed
-
 Command:
-make migrate
-
+    make migrate
 Output:
-Running migrations...
-Applied: scripts/init_db.sql
-Seeding data...
-Applied: scripts/seed.sql
-Done.
+    Running migrations...
+    Applied: scripts/init_db.sql
+    Seeding data...
+    Applied: scripts/seed.sql
+    Done.
 
-Validation:
-- Schema created
-- Seed data inserted
-
-------------------------------------------------------------
-
+===========================================================
 Step 4 — Run pipeline
-
 Command:
-make run
-
+    make run
 Output:
-Starting pipeline...
-Loaded 4 rows from data/raw/sample.csv
-Transformed: 4 -> 2 rows
-Saved 2 rows to data/processed/output.csv
-Pipeline finished successfully
-
-Validation:
-- Data transformed correctly
-- Output file generated
-
-------------------------------------------------------------
-
+    Starting pipeline...
+    Loaded 4 rows from data/raw/sample.csv
+    Transformed: 4 -> 2 rows
+    Saved 2 rows to data/processed/output.csv
+    Pipeline finished successfully
+===========================================================
 Step 5 — Run tests
-
 Command:
-make test
-
+    make test
 Output:
-collected 9 items
-9 passed
+    collected 9 items
+    9 passed
 
-Validation:
-- All unit + pipeline tests pass
-
-------------------------------------------------------------
-
+===========================================================
 Step 6 — DB smoke test
-
 Command:
-make db-smoke
+    make db-smoke
 
 Output:
-tests/test_db_smoke.py PASSED
+    tests/test_db_smoke.py PASSED
+===========================================================
 
-Validation:
-- DB connection works
-- Tables exist
-- Seed data verified
-
-------------------------------------------------------------
-
-Final Result
-
-- Pipeline runs end-to-end from scratch
-- Postgres integration is stable
-- All tests pass locally
-- Workflow is fully reproducible using Makefile
-- Ready for CI validation
-
-------------------------------------------------------------
+Reproducibility commands:
+    make setup
+    make db-up
+    make migrate
+    make run
+    make test
+    make db-smoke

--- a/docs/proof/W02/2026-02-28-run.txt
+++ b/docs/proof/W02/2026-02-28-run.txt
@@ -3,110 +3,55 @@ Proof — W02D5 CI + Reproducibility
 Date: 2026-02-28 (local, Windows)
 Repo: de-lakehouse-pipeline
 
---------------------------------------------------
-
-Environment Setup
-
+============================================================
+step 1 Environment Setup
 Command:
-make setup
+    make setup
+output
+    python -m venv .venv
+    pip install -r requirements.txt
+    Successfully installed de-lakehouse-pipeline-0.1.0
+============================================================
 
-Key Output:
-python -m venv .venv
-pip install -r requirements.txt
-Successfully installed de-lakehouse-pipeline-0.1.0
-
-Result:
-- Virtual environment created
-- Dependencies installed
-- Editable package installed
-
---------------------------------------------------
-
-Lint Check
-
+step 2 Lint Check
 Command:
-make lint
-
+    make lint
 Output:
 All checks passed!
 
-Result:
-- Code passes linting (ruff)
+============================================================
 
---------------------------------------------------
-
-Database Reset
-
+step 3 Database Reset
 Command:
-make db-down
-
+    make db-down
 Output:
-Container removed
-Network removed
-
+    Container removed
+    Network removed
+============================================================
+step 4
 Command:
-make db-up
-
+    make db-up
 Output:
-Container created
-Network created
+    Container created
+    Network created
+============================================================
 
-Result:
-- Fresh Postgres instance started
-
---------------------------------------------------
-
-Run Migrations + Seed
-
+step 5 Run Migrations + Seed
 Command:
-make migrate
-
+    make migrate
 Output:
-Running migrations...
-Applied: migrations\001_init.sql
-Applied: migrations\002_tables.sql
+    Running migrations...
+    Applied: migrations\001_init.sql
+    Applied: migrations\002_tables.sql
+    Seeding data...
+    Applied: scripts\seed.sql
+    Done.
+============================================================
 
-Seeding data...
-Applied: scripts\seed.sql
+Reproducibility commands:
+    make setup
+    make lint
+    make db-down
+    make db-up
+    make migrate
 
-Done.
-
-Result:
-- Migration system executed successfully
-- Schema created (users table)
-- Seed data inserted
-
---------------------------------------------------
-
-Validation (Manual Check)
-
-Expected:
-- users table exists
-- updated_at column exists
-- seed data exists (e.g., Alice, Bob)
-
---------------------------------------------------
-
-Reproducibility Check
-
-Full pipeline:
-make setup
-make lint
-make db-down
-make db-up
-make migrate
-
-Result:
-- Runs without errors
-- No manual steps required
-
---------------------------------------------------
-
-Key Learnings
-
-- Migrations must be idempotent (IF NOT EXISTS)
-- Seed scripts should avoid duplication
-- Makefile ensures reproducibility
-- Logs + tests improve visibility
-
---------------------------------------------------

--- a/docs/proof/W03/2026-03-04-run.txt
+++ b/docs/proof/W03/2026-03-04-run.txt
@@ -2,28 +2,39 @@
 # Date: 2026-03-04 (local, Windows)
 # Repo: de-lakehouse-pipeline
 
-Command: make migrate
-----------------------------------------
-.venv/Scripts/python.exe -m scripts.migrate
-Running migrations...
-Applied: migrations\001_init.sql
-Applied: migrations\002_tables.sql
-Seeding data...
-Applied: scripts\seed.sql
-Done.
+============================================================
+step 1 
+Command: 
+    make migrate
+output:
+    .venv/Scripts/python.exe -m scripts.migrate
+    Running migrations...
+    Applied: migrations\001_init.sql
+    Applied: migrations\002_tables.sql
+    Seeding data...
+    Applied: scripts\seed.sql
+    Done.
+============================================================
+step 2 
+Command: 
+    make lint
+output:
+    .venv/Scripts/python.exe -m ruff check .
+    All checks passed!
+============================================================
+step 3 
+Command: 
+    make smoke
+output:
+    .venv/Scripts/python.exe -m pytest -m smoke
+    platform win32 -- Python 3.11.9, pytest-9.0.2, pluggy-1.6.0
+    collected 11 items / 8 deselected / 3 selected
+    tests\test_db_smoke.py . [ 33%]
+    tests\test_sql_queries.py .. [100%]
+    3 passed, 8 deselected in 1.09s
+============================================================
 
-Command: make lint
-----------------------------------------
-.venv/Scripts/python.exe -m ruff check .
-All checks passed!
-
-Command: make smoke
-----------------------------------------
-.venv/Scripts/python.exe -m pytest -m smoke
-platform win32 -- Python 3.11.9, pytest-9.0.2, pluggy-1.6.0
-collected 11 items / 8 deselected / 3 selected
-
-tests\test_db_smoke.py . [ 33%]
-tests\test_sql_queries.py .. [100%]
-
-3 passed, 8 deselected in 1.09s
+Reproducible Commands:
+    make migrate
+    make lint
+    make smoke

--- a/docs/proof/W03/2026-03-05-run.txt
+++ b/docs/proof/W03/2026-03-05-run.txt
@@ -1,0 +1,25 @@
+# Proof — W03D2 (SQL Unit Tests)
+# Date: 2026-03-05
+# Environment: Local (Windows)
+# Repo: de-lakehouse-pipeline
+
+============================================================
+Step 1 — Run Lint
+Command:
+    make lint
+Output:
+  All checks passed!
+============================================================
+Step 2 — Run SQL Utility Unit Tests
+Command:
+  make sql-utils
+Output:
+  tests/test_sql_utils.py::test_split_sql_statements_basic PASSED
+  tests/test_sql_utils.py::test_split_sql_statements_removes_empty PASSED
+  tests/test_sql_utils.py::test_split_sql_statements_strips_whitespace PASSED
+  tests/test_sql_utils.py::test_split_sql_statements_empty_or_whitespace_input PASSED
+============================================================
+
+Reproducible Commands:
+    make lint
+    make sql-utils

--- a/tests/test_sql_queries.py
+++ b/tests/test_sql_queries.py
@@ -3,18 +3,25 @@ from pathlib import Path
 import pytest
 from de_lakehouse_pipeline.db import connect, load_db_config, wait_for_db
 
+def project_root() -> Path:
+    return Path(__file__).resolve().parents[1]
 
 def _read_sql(path: Path) -> str:
     return path.read_text(encoding="utf-8").strip()
+
+    
+def split_sql_statements(sqls: str) -> list[str]:
+    return [sql.strip() for sql in sqls.split(";") if sql.strip()]
+
 
 
 @pytest.mark.smoke
 def test_window_query_runs() -> None:
     """Window function query file should execute without error."""
-    root = Path(__file__).resolve().parents[1]
+    root = project_root()
     sql_path = root / "sql" / "patterns_window.sql"
-    sql = _read_sql(sql_path)
-    assert sql, "patterns_window.sql is empty"
+    sqls = _read_sql(sql_path)
+    assert sqls, "patterns_window.sql is empty"
 
     cfg = load_db_config()
     wait_for_db(cfg, timeout_s=60)
@@ -22,7 +29,7 @@ def test_window_query_runs() -> None:
     with connect(cfg) as conn:
         with conn.cursor() as cur:
             # Execute only the FIRST statement in the file (up to first ;)
-            first_stmt = sql.split(";")[0].strip()
+            first_stmt = split_sql_statements(sqls)[0]
             cur.execute(first_stmt)
             rows = cur.fetchmany(5)
             assert rows is not None
@@ -31,15 +38,15 @@ def test_window_query_runs() -> None:
 @pytest.mark.smoke
 def test_quality_checks_run() -> None:
     """Quality checks file should execute statement-by-statement without error."""
-    root = Path(__file__).resolve().parents[1]
+    root = project_root()
     sql_path = root / "sql" / "quality_checks.sql"
-    sql = _read_sql(sql_path)
-    assert sql, "quality_checks.sql is empty"
+    sqls = _read_sql(sql_path)
+    assert sqls, "quality_checks.sql is empty"
 
     cfg = load_db_config()
     wait_for_db(cfg, timeout_s=60)
 
-    statements = [s.strip() for s in sql.split(";") if s.strip()]
+    statements = split_sql_statements(sqls)
 
     with connect(cfg) as conn:
         with conn.cursor() as cur:

--- a/tests/test_sql_utils.py
+++ b/tests/test_sql_utils.py
@@ -1,0 +1,28 @@
+from tests.test_sql_queries import split_sql_statements
+
+
+#Verify that split_sql_statements correctly splits a SQL 
+#string into individual statements using the semicolon (;) delimiter.
+#unit test 1
+def test_split_sql_statements_basic() -> None:
+    sql_input = "SELECT 1;    SELECT 2; "
+    sqls = split_sql_statements(sql_input)
+    assert sqls == ["SELECT 1", "SELECT 2"]
+
+#Ensure that split_sql_statements ignores empty SQL fragments caused by consecutive semicolons or trailing semicolons.
+#unti test 2
+def test_split_sql_statements_removes_empty() -> None:
+    sql_input = ";; SELECT 1;; ;\n"
+    sqls = split_sql_statements(sql_input)
+    assert sqls == ["SELECT 1"]
+
+
+#unti test 3
+def test_split_sql_statements_strips_whitespace() ->None:
+    sql_input = "  SELECT 1 ; \n   SELECT 2   ;"
+    sqls = split_sql_statements(sql_input)
+    assert sqls == ["SELECT 1","SELECT 2"]
+#Edge case
+def test_split_sql_statements_empty_or_whitespace_input() ->None:
+    assert split_sql_statements("") == []
+    assert split_sql_statements("   \n\t") == []


### PR DESCRIPTION
## Purpose
- Add unit tests for SQL utility logic used to split SQL files into executable statements
- Cover common edge cases such as empty fragments, trailing semicolons, and whitespace-only input

## What's included
- Added `tests/test_sql_utils.py`
- Added unit tests for `split_sql_statements`
  - basic split behavior
  - removal of empty SQL fragments
  - whitespace trimming
  - empty / whitespace-only input handling
- Proof log for today’s validation run

## Proof & Validation
- **Artifacts**:
  - `tests/test_sql_utils.py`
  - `docs/proof/2026-03-05-run.txt`
- **Commands**:
  - `make lint`
  - `make sql-utils`