### PR TITLE
[W16D03]feat: add Terraform raw storage baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ venv/
 .pytest_cache/
 plan.docx
 archive
+
+
+infra/terraform/.terraform/
+infra/terraform/terraform.tfstate
+infra/terraform/terraform.tfstate.backup
+infra/terraform/*.tfplan

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,14 @@ cloud-storage-test:
 
 tree:
 	$(PY) tree_tool.py
+	
+terraform-check:
+	cd infra/terraform && terraform fmt -check && terraform plan -var="raw_bucket_name=eric-lakehouse-raw-dev-20260601"
+
+price-dashboard:
+	$(PY) -m streamlit run scripts/price_dashboard.py
+	
+#database ---
 
 db-shell:
 	docker exec -it de_lakehouse_db psql -U lakehouse -d lakehouse

--- a/docs/CLOUD_STORAGE.md
+++ b/docs/CLOUD_STORAGE.md
@@ -1,32 +1,38 @@
-# Cloud Storage
-
-## Purpose
-
-This document explains how the project can optionally upload raw API payloads to S3.
-
-The cloud storage layer is used for keeping a raw copy of source data before transformation and database loading.
-
-## Current Scope
-
-This version supports:
-
-- building a partitioned S3 object key
-- optionally uploading raw JSON payloads to S3
-- skipping upload when cloud upload is disabled
-- validating required environment variables
-
-This PR does not provision AWS infrastructure yet.
-
-## Environment Variables
-
-| Variable | Required | Description |
-|---|---:|---|
-| `ENABLE_S3_RAW_UPLOAD` | No | Must be set to `true` to enable S3 upload |
-| `S3_RAW_BUCKET` | Yes, if upload is enabled | S3 bucket name for raw payload storage |
-
 ## Raw Object Key Pattern
 
 Raw files use this partitioned layout:
 
 ```text
 raw/{source}/symbol={SYMBOL}/date={YYYY-MM-DD}/{filename}
+```
+
+Example:
+
+```text
+raw/alpha_vantage/symbol=AAPL/date=2026-05-28/stock.json
+```
+
+## Least-Privilege IAM Plan
+
+The pipeline only needs permission to upload raw payloads to the configured raw S3 bucket.
+
+Required permission:
+
+- `s3:PutObject` on `arn:aws:s3:::<bucket-name>/raw/*`
+
+The pipeline does not need:
+
+- `s3:DeleteObject`
+- `s3:ListAllMyBuckets`
+- write access to other buckets
+- administrator permissions
+
+Example policy shape:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": ["s3:PutObject"],
+  "Resource": "arn:aws:s3:::<bucket-name>/raw/*"
+}
+```

--- a/docs/WEEKLY_LOG.md
+++ b/docs/WEEKLY_LOG.md
@@ -819,3 +819,18 @@ python -m pytest tests/unit -v
 - Verified cloud storage unit and smoke tests.
 - Confirmed CI already runs the cloud storage unit test path.
 
+
+### W16D03 (2026-06-06) - Terraform AWS apply and clean destroy
+**Deliverables**
+- Configured AWS credentials locally and confirmed Terraform can connect to AWS.
+- Ran `terraform init` successfully and installed the AWS provider.
+- Ran `terraform plan` successfully with `raw_bucket_name=eric-lakehouse-raw-dev-20260601`.
+- Ran `terraform apply` and created 2 AWS resources:
+  - `aws_s3_bucket.raw`
+  - `aws_iam_policy.raw_writer`
+- Verified Terraform outputs:
+  - `raw_bucket_name`
+  - `raw_bucket_arn`
+  - `raw_writer_policy_arn`
+- Ran `terraform destroy` and removed both AWS resources cleanly.
+- Confirmed Week 16 Terraform workflow works end-to-end: `plan -> apply -> outputs -> destroy`.

--- a/docs/proof/W16/2026-06-03-run.txt
+++ b/docs/proof/W16/2026-06-03-run.txt
@@ -1,0 +1,27 @@
+# Proof — W016D03
+# Date: 2026-06-06
+# Repo: de-lakehouse-pipeline
+==================================================
+
+Commands:
+    cd C:\Users\liuxu\de-lakehouse-pipeline\infra\terraform
+    terraform init
+    terraform plan -var="raw_bucket_name=eric-lakehouse-raw-dev-20260601"
+    terraform apply -var="raw_bucket_name=eric-lakehouse-raw-dev-20260601"
+    terraform destroy -var="raw_bucket_name=eric-lakehouse-raw-dev-20260601"
+
+Terraform apply result:
+- aws_s3_bucket.raw created successfully.
+- aws_iam_policy.raw_writer created successfully.
+- Apply complete: Resources: 2 added, 0 changed, 0 destroyed.
+
+Outputs:
+- raw_bucket_name = eric-lakehouse-raw-dev-20260601
+- raw_bucket_arn = arn:aws:s3:::eric-lakehouse-raw-dev-20260601
+- raw_writer_policy_arn = arn:aws:iam::571741814140:policy/eric-lakehouse-raw-dev-20260601-raw-writer
+
+Terraform destroy result:
+- aws_iam_policy.raw_writer destroyed successfully.
+- aws_s3_bucket.raw destroyed successfully.
+- Destroy complete: Resources: 2 destroyed.
+

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -3,8 +3,9 @@
 This directory contains the initial Terraform scaffold for Week 15 cloud deployment work.
 
 ## Current Scope
-This PR only adds the Terraform structure.
-It does not create real AWS resources yet.
+This Terraform module creates:
+- one raw S3 bucket
+- one IAM policy for raw uploads
 
 ## Planned Resources
 

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,21 +1,37 @@
 terraform {
   required_version = ">= 1.5.0"
-
+  # 项目需要使用 AWS provider。 需要 AWS provider 来和 AWS 通信。
   required_providers {
     aws = {
+      # 使用 HashiCorp 官方维护的 AWS provider。
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
   }
 }
-
+#配置 AWS provider。要在哪个 AWS region 创建资源。
 provider "aws" {
   region = var.aws_region
 }
 
-# Placeholder for Week 15 cloud deployment.
-# Later PRs will add:
-# - raw S3 bucket
-# - least-privilege IAM policy
-# - runtime role/user permissions
-# - lifecycle and cost controls
+resource "aws_s3_bucket" "raw" {
+  bucket = var.raw_bucket_name
+}
+#IAM policy 的作用是：定义某个用户、角色、程序可以做什么，不可以做什么。
+resource "aws_iam_policy" "raw_writer" {
+  name        = "${var.raw_bucket_name}-raw-writer"
+  description = "Allow the pipeline to upload raw payloads only."
+  #AWS IAM Policy 本质上是 JSON。但是在 Terraform 里写 JSON 很麻烦，所以 Terraform 提供了：
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject"
+        ]
+        Resource = "${aws_s3_bucket.raw.arn}/raw/*"
+      }
+    ]
+  })
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -2,3 +2,12 @@ output "raw_bucket_name" {
   description = "Configured raw S3 bucket name."
   value       = var.raw_bucket_name
 }
+output "raw_bucket_arn" {
+  description = "ARN of the raw S3 bucket."
+  value       = aws_s3_bucket.raw.arn
+}
+
+output "raw_writer_policy_arn" {
+  description = "ARN of the IAM policy that allows raw payload uploads."
+  value       = aws_iam_policy.raw_writer.arn
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,7 @@ requests
 boto3
 #读取.env 文件用的
 python-dotenv
+
+#visualization
+pandas
+streamlit

--- a/scripts/price_dashboard.py
+++ b/scripts/price_dashboard.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+
+from de_lakehouse_pipeline.load.db.connection import (
+    connect,
+    load_db_config,
+    wait_for_db,
+)
+
+
+def load_price_changes(symbol: str, limit: int = 30) -> pd.DataFrame:
+    sql = """
+        WITH price_changes AS (
+            SELECT
+                symbol,
+                ts::date AS trading_date,
+                close AS close_price,
+                LAG(close) OVER (
+                    PARTITION BY symbol
+                    ORDER BY ts
+                ) AS previous_close,
+                close - LAG(close) OVER (
+                    PARTITION BY symbol
+                    ORDER BY ts
+                ) AS price_change,
+                ROUND(
+                    (
+                        (close - LAG(close) OVER (
+                            PARTITION BY symbol
+                            ORDER BY ts
+                        ))
+                        / NULLIF(LAG(close) OVER (
+                            PARTITION BY symbol
+                            ORDER BY ts
+                        ), 0)
+                    ) * 100,
+                    2
+                ) AS change_pct,
+                volume
+            FROM market_bars
+            WHERE symbol = %s
+        )
+        SELECT
+            symbol,
+            trading_date,
+            close_price,
+            previous_close,
+            price_change,
+            change_pct,
+            volume
+        FROM price_changes
+        ORDER BY trading_date DESC
+        LIMIT %s;
+    """
+
+    cfg = load_db_config()
+    wait_for_db(cfg, timeout_s=60)
+
+    with connect(cfg) as conn:
+        return pd.read_sql(sql, conn, params=(symbol, limit))
+
+
+def render_dashboard() -> None:
+    st.set_page_config(
+        page_title="Stock Price Changes",
+        page_icon="📈",
+        layout="wide",
+    )
+
+    st.title("Stock Price Changes")
+
+    symbol = st.sidebar.text_input("Symbol", value="AAPL").upper()
+    limit = st.sidebar.slider("Rows", min_value=7, max_value=120, value=30)
+
+    df = load_price_changes(symbol=symbol, limit=limit)
+
+    if df.empty:
+        st.warning(f"No price data found for {symbol}.")
+        return
+
+    latest = df.iloc[0]
+
+    col1, col2, col3 = st.columns(3)
+
+    col1.metric(
+        "Latest Close",
+        f"${latest['close_price']:.2f}",
+    )
+
+    col2.metric(
+        "Price Change",
+        f"${latest['price_change']:.2f}"
+        if latest["price_change"] is not None
+        else "N/A",
+    )
+
+    col3.metric(
+        "Change %",
+        f"{latest['change_pct']:.2f}%"
+        if latest["change_pct"] is not None
+        else "N/A",
+    )
+
+    chart_df = df.sort_values("trading_date")
+
+    st.subheader("Close Price Trend")
+    st.line_chart(
+        chart_df,
+        x="trading_date",
+        y="close_price",
+    )
+
+    st.subheader("Price Change Table")
+    st.dataframe(
+        df,
+        use_container_width=True,
+        hide_index=True,
+    )
+
+
+if __name__ == "__main__":
+    render_dashboard()


### PR DESCRIPTION
##  What's included
- Configured AWS credentials locally and confirmed Terraform can connect to AWS.
- Ran `terraform init` successfully and installed the AWS provider.
- Ran `terraform plan` successfully with `raw_bucket_name=eric-lakehouse-raw-dev-20260601`.
- Ran `terraform apply` and created 2 AWS resources:
  - `aws_s3_bucket.raw`
  - `aws_iam_policy.raw_writer`
- Verified Terraform outputs:
  - `raw_bucket_name`
  - `raw_bucket_arn`
  - `raw_writer_policy_arn`
- Ran `terraform destroy` and removed both AWS resources cleanly.
- Confirmed Week 16 Terraform workflow works end-to-end: `plan -> apply -> outputs -> destroy`.
