### PR TITLE
[W17D03]feat: add source tracking to market bars

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -19,6 +19,7 @@ One row per `(ts, symbol)`.
 - `low`: low price
 - `close`: closing price
 - `volume`: traded volume
+- `source`: upstream source name for this market bar row; defaults to alpha_vantage
 
 ### Quality Rules
 - `ts` must not be null

--- a/docs/WEEKLY_LOG.md
+++ b/docs/WEEKLY_LOG.md
@@ -926,3 +926,12 @@ terraform destroy
   - analytical marts
   - FastAPI serving/dashboard
 - Added `docs/RUNBOOK.md` with local run commands, validation commands, database inspection queries, troubleshooting steps, and proof checklist.
+
+
+### W17D03   Schema Evolution: market_bars source
+- Added `source` column to `market_bars`.
+- Used default value `alpha_vantage` so existing rows and old inserts remain compatible.
+- Updated staging logic so each staged market bar carries a source value.
+- Updated database load logic so `source` is written explicitly.
+- Updated unit tests for the new tuple shape.
+- Updated `docs/DATA_MODEL.md` to document the new field.

--- a/docs/proof/W17/2026-06-08-run.md
+++ b/docs/proof/W17/2026-06-08-run.md
@@ -1,5 +1,5 @@
-# Proof — W016D04
-# Date: 2026-06-07
+# Proof — W017D01
+# Date: 2026-06-08
 # Repo: de-lakehouse-pipeline
 # Scope: Dashboard / Serving: Minimal Visualization and Query API
 ==================================================

--- a/docs/proof/W17/2026-06-11-run.txt
+++ b/docs/proof/W17/2026-06-11-run.txt
@@ -1,0 +1,23 @@
+# Proof — W017D03
+# Date: 2026-06-11
+# Repo: de-lakehouse-pipeline
+==================================================
+step 1:
+Command:
+    make db-down
+    make db-up
+Output:
+    [+] down 2/2
+    ✔ Container de_lakehouse_db             Removed                                                                                                                                0.4s
+    ✔ Network de-lakehouse-pipeline_default Removed                                                                                                                                0.3s
+    docker compose up -d
+    [+] up 2/2
+    ✔ Network de-lakehouse-pipeline_default Created                                                                                                                                0.0s
+    ✔ Container de_lakehouse_db             Created 
+==================================================
+step 2:
+Command:
+    make unit
+Output:
+    collected 69 items                                                                                                                                                              
+    PASSED!

--- a/migrations/008_add_source_to_market_bars.sql
+++ b/migrations/008_add_source_to_market_bars.sql
@@ -1,0 +1,2 @@
+ALTER TABLE market_bars
+ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'alpha_vantage';

--- a/src/de_lakehouse_pipeline/checkdb.py
+++ b/src/de_lakehouse_pipeline/checkdb.py
@@ -11,7 +11,7 @@ def view_market_bars():
         df = pd.read_sql(
         """
         SELECT *
-        FROM stg_market_bars
+        FROM market_bars
         """,
         conn
     )

--- a/src/de_lakehouse_pipeline/load/db/stock_writer.py
+++ b/src/de_lakehouse_pipeline/load/db/stock_writer.py
@@ -1,31 +1,35 @@
+def upsert_stock_prices(conn, rows, source: str = "unknown"):
+    normalized_rows = []
 
-def upsert_stock_prices(conn, rows: list[tuple]) -> None:
-    """
-    Insert or update stock price rows into market_bars.
-    """
+    for row in rows:
+        if len(row) == 7:
+            ts, symbol, open_, high, low, close, volume = row
+            normalized_rows.append(
+                (ts, symbol, open_, high, low, close, volume, source)
+            )
+        elif len(row) == 8:
+            normalized_rows.append(row)
+        else:
+            raise ValueError(
+                f"Expected row with 7 or 8 values, got {len(row)}: {row}"
+            )
+
     sql = """
         INSERT INTO market_bars (
-            ts, symbol, open, high, low, close, volume,source
+            ts, symbol, open, high, low, close, volume, source
         )
         VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-        ON CONFLICT (ts, symbol)
-        DO UPDATE SET 
-        open = EXCLUDED.open,
-        high = EXCLUDED.high,
-        low = EXCLUDED.low,
-        close = EXCLUDED.close,
-        volume = EXCLUDED.volume,
-        source= EXCLUDED.source
+        ON CONFLICT (ts, symbol) DO UPDATE SET
+            open = EXCLUDED.open,
+            high = EXCLUDED.high,
+            low = EXCLUDED.low,
+            close = EXCLUDED.close,
+            volume = EXCLUDED.volume,
+            source = EXCLUDED.source
     """
-#EXCLUDED.open = 新传进来的 open
-    with conn.cursor() as cur:
-        #executemany = 
-        #       for row in rows:
-             #  cur.execute(sql, row)
-        #
-        cur.executemany(sql, rows)
-    conn.commit()
 
+    with conn.cursor() as cur:
+        cur.executemany(sql, normalized_rows)
 
 def should_update_watermark_after_load(load_success: bool) -> bool:
     """Watermark should only move forward after a successful load."""

--- a/src/de_lakehouse_pipeline/load/db/stock_writer.py
+++ b/src/de_lakehouse_pipeline/load/db/stock_writer.py
@@ -5,16 +5,17 @@ def upsert_stock_prices(conn, rows: list[tuple]) -> None:
     """
     sql = """
         INSERT INTO market_bars (
-            ts, symbol, open, high, low, close, volume
+            ts, symbol, open, high, low, close, volume,source
         )
-        VALUES (%s, %s, %s, %s, %s, %s, %s)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
         ON CONFLICT (ts, symbol)
         DO UPDATE SET 
         open = EXCLUDED.open,
         high = EXCLUDED.high,
         low = EXCLUDED.low,
         close = EXCLUDED.close,
-        volume = EXCLUDED.volume;
+        volume = EXCLUDED.volume,
+        source= EXCLUDED.source
     """
 #EXCLUDED.open = 新传进来的 open
     with conn.cursor() as cur:

--- a/src/de_lakehouse_pipeline/transform/staging/staging_market_bars.py
+++ b/src/de_lakehouse_pipeline/transform/staging/staging_market_bars.py
@@ -14,6 +14,7 @@ class StagedMarketBar:
     low: float
     close: float
     volume: int
+    source: str = "alpha_vantage"
 
 
 def stage_alpha_vantage_daily(payload: dict) -> list[StagedMarketBar]:
@@ -53,6 +54,7 @@ def to_db_tuple(row: StagedMarketBar) -> tuple:
         row.low,
         row.close,
         row.volume,
+        row.source
     )
 
 

--- a/tests/smoke/test_pipeline_smoke.py
+++ b/tests/smoke/test_pipeline_smoke.py
@@ -55,7 +55,7 @@ def test_small_sample_stock_payload_returns_expected_tuple_shape() -> None:
 
     for row in rows:
         assert isinstance(row, tuple)
-        assert len(row) == 7
+        assert len(row) == 8
 
 
 @pytest.mark.smoke

--- a/tests/unit/test_staging_market_bars.py
+++ b/tests/unit/test_staging_market_bars.py
@@ -40,6 +40,7 @@ def test_stage_alpha_vantage_daily_returns_typed_market_bar() -> None:
             low=197.25,
             close=200.3,
             volume=1234567,
+            source= "alpha_vantage"
         )
     ]
 
@@ -65,7 +66,7 @@ def test_to_db_tuple_preserves_market_bars_column_order() -> None:
         high=201.5,
         low=197.25,
         close=200.3,
-        volume=1234567,
+        volume=1234567
     )
 
     assert to_db_tuple(row) == (
@@ -76,6 +77,7 @@ def test_to_db_tuple_preserves_market_bars_column_order() -> None:
         197.25,
         200.3,
         1234567,
+        "alpha_vantage"
     )
 
 


### PR DESCRIPTION
##  What's included
- Added `source` column to `market_bars`.
- Used default value `alpha_vantage` so existing rows and old inserts remain compatible.
- Updated staging logic so each staged market bar carries a source value.
- Updated database load logic so `source` is written explicitly.
- Updated unit tests for the new tuple shape.
- Updated `docs/DATA_MODEL.md` to document the new field.
